### PR TITLE
Support for easier customization of messages

### DIFF
--- a/bottle_utils/form.py
+++ b/bottle_utils/form.py
@@ -429,8 +429,9 @@ class Form(object):
         the form is allowed."""
         types = (Field, DormantField)
         is_form_field = lambda name: isinstance(getattr(self, name), types)
+        ignored_attrs = ['fields', 'messages']
         return dict((name, getattr(self, name)) for name in dir(self)
-                    if name != 'fields' and is_form_field(name))
+                    if name in ignored_attrs and is_form_field(name))
 
     def _add_error(self, field, error):
         # if the error is from one of the processors, bind it to the field too

--- a/bottle_utils/form.py
+++ b/bottle_utils/form.py
@@ -431,7 +431,7 @@ class Form(object):
         is_form_field = lambda name: isinstance(getattr(self, name), types)
         ignored_attrs = ['fields', 'messages']
         return dict((name, getattr(self, name)) for name in dir(self)
-                    if name in ignored_attrs and is_form_field(name))
+                    if name not in ignored_attrs and is_form_field(name))
 
     def _add_error(self, field, error):
         # if the error is from one of the processors, bind it to the field too

--- a/bottle_utils/form.py
+++ b/bottle_utils/form.py
@@ -430,12 +430,11 @@ class Form(object):
 
     def _bind(self, data):
         """Binds field names and values to the field instances."""
-        if data is None:
-            return
         for field_name, dormant_field in self.fields.items():
             field_instance = dormant_field.bind(field_name)
             setattr(self, field_name, field_instance)
-            field_instance.bind_value(data.get(field_name))
+            if data is not None:
+                field_instance.bind_value(data.get(field_name))
 
     @property
     def field_messages(self):

--- a/bottle_utils/form.py
+++ b/bottle_utils/form.py
@@ -409,6 +409,20 @@ class Form(object):
                 field_instance.bind_value(data.get(field_name))
 
     @property
+    def messages(self):
+        """ Dictionary of all field error messages
+
+        This value maps the field names to error message maps. Field names are
+        mapped to fields' messages property, which maps error type to actual
+        message. This dictionary can also be used to modify the messages
+        because message mappings are not copied.
+        """
+        messages = {}
+        for field_name, field in self.fields.items():
+            messages[field_name] = field.messages
+        return messages
+
+    @property
     def fields(self):
         """Returns a dictionary of all the fields found on the form instance.
         The return value is never cached so dynamically adding new fields to

--- a/bottle_utils/form.py
+++ b/bottle_utils/form.py
@@ -88,7 +88,8 @@ class Required(Validator):
 
     def validate(self, data):
         if not data or isinstance(data, basestring) and not data.strip():
-            raise ValidationError('required', {})
+            # Translator, represents empty field's value
+            raise ValidationError('required', {'value': _('(empty)')})
 
 
 class DateValidator(Validator):
@@ -143,7 +144,7 @@ class Field(object):
 
     # Translators, used as generic error message in form fields, 'value' should
     # not be translated.
-    generic_error = _('{value} is invalid for this field')
+    generic_error = _('Invalid value for this field')
 
     def __new__(cls, *args, **kwargs):
         if 'name' in kwargs:

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -322,6 +322,16 @@ class TestForm(object):
         validate.assert_called_once_with()
         assert form.error == error
 
+    @mock.patch.object(mod.Field, 'messages')
+    def test_form_error_messages(self, messages, form_cls):
+        form = form_cls({})
+        form.field1.messages = {'foo': 'bar'}
+        form.field2.messages = {'bar': 'baz'}
+        assert form.messages == {
+            'field1': {'foo': 'bar'},
+            'field2': {'bar': 'baz'},
+        }
+
 
 @mock.patch.object(mod, '_')
 def test_form_integration(gettext):

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -138,7 +138,6 @@ class TestField(object):
         assert 'bar' in field.messages
 
 
-
 class TestStringField(object):
 
     def test_parse(self):


### PR DESCRIPTION
Messages are defined as maps between (short) generic message names and full
message strings. These messages are collected into fields so they can be
overridden easily using the messages property.
